### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
           path: "main.tex"
 
       - name: Compile LaTeX document
-        uses: xu-cheng/latex-action@3.2.0
+        uses: xu-cheng/latex-action@3.3.0
         with:
           working_directory: "."
           root_file: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[xu-cheng/latex-action](https://github.com/xu-cheng/latex-action)** published a new release **[3.3.0](https://github.com/xu-cheng/latex-action/releases/tag/3.3.0)** on 2025-04-28T03:05:04Z
